### PR TITLE
specify package name to `after_stat()`

### DIFF
--- a/R/gf_functions.R
+++ b/R/gf_functions.R
@@ -1173,7 +1173,7 @@ gf_dhistogram <-
       ),
     note =
         "y may be after_stat(density) or after_stat(count) or after_stat(ndensity) or after_stat(ncount)",
-    aesthetics = aes(y = after_stat(density))
+    aesthetics = aes(y = ggplot2::after_stat(density))
   )
 
 #' Formula interface to stat_density()
@@ -1220,7 +1220,7 @@ gf_density <-
       # size = , # remove eventually?
       kernel = "gaussian", n = 512, trim = FALSE
     ),
-    aesthetics = aes(y = after_stat(density))
+    aesthetics = aes(y = ggplot2::after_stat(density))
   )
 
 #' @rdname gf_density
@@ -1237,7 +1237,7 @@ gf_dens <-
       # size = , # remove eventually?
       kernel = "gaussian", n = 512, trim = FALSE
     ),
-    aesthetics = aes(y = after_stat(density))
+    aesthetics = aes(y = ggplot2::after_stat(density))
   )
 
 #' @rdname gf_density
@@ -1254,7 +1254,7 @@ gf_dens2 <-
       # size = , # remove eventually?
       kernel = "gaussian", n = 512, trim = FALSE
     ),
-    aesthetics = aes(y = after_stat(density))
+    aesthetics = aes(y = ggplot2::after_stat(density))
   )
 #' Formula interface to geom_dotplot()
 #'
@@ -1456,7 +1456,7 @@ gf_props <-
         # size = , # remove eventually?
         ylab = "proportion"
       ),
-    aesthetics = aes(y = after_stat(props_by_group(count, DENOM))),
+    aesthetics = aes(y = ggplot2::after_stat(props_by_group(count, DENOM))),
     # pre = { aesthetics[['y']][[2]][[2]][[3]] <- rlang::f_rhs(denom) },
     pre = {
       yaes_expr <- rlang::quo_get_expr(aesthetics[['y']]);
@@ -1478,7 +1478,7 @@ gf_percents <-
       # size = , # remove eventually?
       ylab = "percent"
     ),
-    aesthetics = aes(y = after_stat(percs_by_group(count, DENOM))),
+    aesthetics = aes(y = ggplot2::after_stat(percs_by_group(count, DENOM))),
     pre = {
       yaes_expr <- rlang::quo_get_expr(aesthetics[['y']]);
       yaes_expr[[2]][[3]] <- rlang::f_rhs(denom) ;

--- a/R/ggstance.R
+++ b/R/ggstance.R
@@ -98,7 +98,7 @@ gf_propsh <-
         alpha = , color = , fill = , group = ,
         linetype = , linewidth = , xlab = "proportion"
       ),
-    aesthetics = aes(x = after_stat(props_by_group(count, DENOM))),
+    aesthetics = aes(x = ggplot2::after_stat(props_by_group(count, DENOM))),
     pre = {
       xaes_expr <- rlang::quo_get_expr(aesthetics[['x']]);
       xaes_expr[[2]][[3]] <- rlang::f_rhs(denom) ;
@@ -117,7 +117,7 @@ gf_percentsh <-
       alpha = , color = , fill = , group = ,
       linetype = , linewidth = , xlab = "percent"
     ),
-    aesthetics = aes(x = after_stat(percs_by_group(count, DENOM))),
+    aesthetics = aes(x = ggplot2::after_stat(percs_by_group(count, DENOM))),
     pre = {
       xaes_expr <- rlang::quo_get_expr(aesthetics[['x']]);
       xaes_expr[[2]][[3]] <- rlang::f_rhs(denom) ;
@@ -243,7 +243,7 @@ gf_dhistogramh <-
     extras =
       alist(bins = 25, binwidth = , alpha = 0.5, color = , fill = , group = , linetype = , linewidth = ),
     note = "x may be after_stat(density) or after_stat(count) or after_stat(ndensity) or after_stat(ncount)",
-    aesthetics = aes(x = after_stat(density))
+    aesthetics = aes(x = ggplot2::after_stat(density))
   )
 
 #' @rdname gf_linerange


### PR DESCRIPTION
# What I Changed

This pull request adds `ggplot2::` in front of `after_stat(*)` in function definitions. I excluded test files and comments (including Roxygen2 comments).

# Why I Changed It

I am working on creating a package that includes some wrapper functions around select `ggformula` functions. This is designed for introductory statistics students at my university and allows for pretty tables and pre-customized plots so students can focus on the concepts and not the R code. All of my functions work great, the examples run fine, and running things interactively work as well.

However, running `devtools::check()` on my package leads to check failure. The reasoning is that R "could not function `after_stat`". It's strange that this happens since `ggplot2` is a required package for this package and for mine so you'd think that it would work (plus other `ggplot2` functions in this package work without problems). I suppose that there could be other reasons why this error occurs, but looking through the source code here, I noticed that this function was not specified with `::` notation. My experience with working on packages and getting the "function not found" error is that I need to use `function::` to correct the error.

I'm happy to discuss alternatives to this correction or other potential places I could have gone wrong. Thank you!