### PR TITLE
fix StatLm duplicate formula arg when lm.args supplies formula

### DIFF
--- a/R/newplots.R
+++ b/R/newplots.R
@@ -589,6 +589,9 @@ StatLm <-
           data = quote(data),
           weights = quote(weight)
         )
+        # lm.args may supply its own formula (e.g. y ~ poly(x, 2)); if so,
+        # drop base.args$formula to avoid "matched by multiple actual arguments"
+        if (!is.null(lm.args$formula)) base.args$formula <- NULL
         model <- do.call(stats::lm, c(base.args, lm.args))
       }
 


### PR DESCRIPTION
Hey Randall -- just a tiny edit! Thanks as always for all your awesome work on mosaic/ggformula/etc.

## Summary

When `lm.args = list(formula = y ~ poly(x, 2))` is passed to `gf_lm()` or `stat_lm()`, the call to `do.call(stats::lm, c(base.args, lm.args))` fails with:

> formal argument "formula" matched by multiple actual arguments

because `base.args` already contains `formula = y ~ x` (the default), and `lm.args` adds a second `formula` key.

The fix is one line: drop `base.args$formula` before merging when `lm.args` already provides its own formula, so the user-supplied formula wins cleanly.

## Reproduction

```r
library(ggformula)
data(KidsFeet, package = "mosaicData")

# Before fix: error "matched by multiple actual arguments"
# After fix: draws a quadratic fit
gf_point(length ~ width, data = KidsFeet) |>
  gf_lm(lm.args = list(formula = y ~ poly(x, 2)))
```

Note: the `formula = y ~ poly(x, 2)` direct-param syntax already works; this fixes the `lm.args` path to be consistent.

## Test plan
- [ ] Verify `lm.args = list(formula = ...)` no longer errors
- [ ] Verify `lm.args = list(formula = ...)` produces the same fit as `formula = ...` directly
- [ ] Verify default behavior (`lm.args = list()`) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)